### PR TITLE
Add VT_API_KEY env variable to README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -14,6 +14,12 @@ Install:
 ▶ go get github.com/tomnomnom/waybackurls
 ```
 
+Include [VirusTotal](https://developers.virustotal.com/reference) URL data (optional):
+
+```
+▶ export VT_API_KEY=<VIRUSTOTAL API KEY>
+```
+
 ## Credit
 
 This tool was inspired by @mhmdiaa's [waybackurls.py](https://gist.github.com/mhmdiaa/adf6bff70142e5091792841d4b372050) script.


### PR DESCRIPTION
It would be helpful to expose in README the VirusTotal feature