### PR TITLE
Update Common Crawl index

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func getCommonCrawlURLs(domain string, noSubs bool) ([]wurl, error) {
 	}
 
 	res, err := http.Get(
-		fmt.Sprintf("http://index.commoncrawl.org/CC-MAIN-2018-22-index?url=%s%s/*&output=json", subsWildcard, domain),
+		fmt.Sprintf("http://index.commoncrawl.org/CC-MAIN-2021-31-index?url=%s%s/*&output=json", subsWildcard, domain),
 	)
 	if err != nil {
 		return []wurl{}, err


### PR DESCRIPTION
Thanks @tomnomnom for the excellent tool. I noticed the index being used for Common Crawl is a bit out of date, so this updates to the most recent (the newer contains 3.15 billion URLs and the older 2.75 billion):

https://commoncrawl.org/2018/06/may-2018-crawl-archive-now-available/
https://commoncrawl.org/2021/08/july-august-2021-crawl-archive-available/