### PR TITLE
Updated Readme.mkd

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -10,8 +10,8 @@ Usage example:
 
 Install:
 
-```
-▶ go get github.com/tomnomnom/waybackurls
+```bash
+go install github.com/tomnomnom/waybackurls@latest
 ```
 
 ## Credit


### PR DESCRIPTION
Go get is not supported now , it must be replaced with go install , and other than this ,version must be declare , here @latest means installing latest version of Waybackurl.
so that final installation command will be 

`go install github.com/tomnomnom/waybackurls@latest`