### PR TITLE
Update installation method of waybackurls - README.mkd document updated.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -11,7 +11,7 @@ Usage example:
 Install:
 
 ```
-▶ go get github.com/tomnomnom/waybackurls
+▶ go install github.com/tomnomnom/waybackurls@latest
 ```
 
 ## Credit


### PR DESCRIPTION
Installing executables with 'go get' in module mode is deprecated, so we need to use  'go install' instead of 'go get'. So, updated the installation method accordingly in README.mkd document.