### PR TITLE
updated install instructions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -11,7 +11,7 @@ Usage example:
 Install:
 
 ```
-▶ go get github.com/tomnomnom/waybackurls
+▶ go install github.com/tomnomnom/waybackurls@latest
 ```
 
 ## Credit


### PR DESCRIPTION
in latest version of go, we need to use `go install` instead of `go get` and the `<version>` at the end