### PR TITLE
Update README.mkd

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -5,13 +5,13 @@ Accept line-delimited domains on stdin, fetch known URLs from the Wayback Machin
 Usage example:
 
 ```
-▶ cat domains.txt | waybackurls > urls
+cat domains.txt | waybackurls > urls
 ```
 
 Install:
 
 ```
-▶ go install github.com/tomnomnom/waybackurls@latest
+go install github.com/tomnomnom/waybackurls@latest
 ```
 
 ## Credit


### PR DESCRIPTION
It'll be easier to simply copy to clipboard without the special character as most of the time we just need to copy and paste the command and hit enter! (Not a issue)